### PR TITLE
adding inertia scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ onSelect | Function | Callback when item selected, return item key | false | nul
 onUpdate | Function | Callback when menu position changed, return { translate: 0 } | false | null
 scrollToSelected | Boolean | Scroll to `selected` props passed on mount and when props changed | false | false
 scrollBy | Number | How many menu items to scroll, 0 for all visible | false | 0
+inertiaScrolling | Boolean | Use inertia for scrolling, duration depends on transition and slowdown | false | false
+inertiaScrollingSlowdown | Float Number | Slow down factor for inertia scrolling | false | 0.25
 
 ## Programmaticaly change things
 You can scroll left/right via `componentRef.handleArrowClick()` and `componentRef.handleArrowClickRight()` functions.

--- a/examples/src/App.js
+++ b/examples/src/App.js
@@ -69,6 +69,8 @@ class App extends Component {
     transition: 0.4,
     wheel: true,
     showList: true,
+    inertiascrolling: false,
+    slowdownFactor: 0.25,
   };
 
   constructor(props) {
@@ -117,6 +119,10 @@ class App extends Component {
     }
   };
 
+  setSlowdownFactor = ev => {
+    this.setState({slowdownFactor: ev.target.value});
+  }
+
   setSelected = ev => {
     const {value} = ev.target;
     this.setState({selected: String(value)});
@@ -140,6 +146,8 @@ class App extends Component {
       wheel,
       showList,
       scrollToSelected,
+      inertiascrolling,
+      slowdownFactor,
     } = this.state;
 
     const menu = this.menuItems;
@@ -183,6 +191,8 @@ class App extends Component {
             dragging={dragging}
             clickWhenDrag={clickWhenDrag}
             wheel={wheel}
+            inertiaScrolling={inertiascrolling}
+            inertiaScrollingSlowdown={slowdownFactor}
           />
         )}
 
@@ -290,6 +300,25 @@ class App extends Component {
               min={0}
               max={list.length}
               onChange={this.setItemsCount}
+            />
+          </label>
+          <label style={checkboxStyle}>
+            Inertia Scrolling
+            <input
+              name="inertiascrolling"
+              type="checkbox"
+              checked={inertiascrolling}
+              onChange={() => this.setState({inertiascrolling: !inertiascrolling})}
+            />
+          </label>
+          <label style={valueStyle}>
+            Inertia scrolling slowdown:
+            <input
+              style={{margin: '0 5px'}}
+              name="slowdownFactor"
+              type="number"
+              value={slowdownFactor}
+              onChange={this.setSlowdownFactor}
             />
           </label>
         </form>

--- a/src/defautSettings.ts
+++ b/src/defautSettings.ts
@@ -56,6 +56,10 @@ const defaultProps: MenuProps = {
   dragging: true,
   /** array of MenuItem elements */
   data: [],
+  /** enable/disable inertia scrolling */
+  inertiaScrolling: false,
+  /** slow down factor for inertia scrolling */
+  inertiaScrollingSlowdown: 0.25,
   /** styles for InnerWrapper */
   innerWrapperStyle: defaultInnerWrapperStyle,
   /** class for InnerWrapper */

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,8 @@ interface MenuProps {
   clickWhenDrag: boolean,
   dragging: boolean,
   data: Data,
+  inertiaScrolling: boolean,
+  inertiaScrollingSlowdown: number,
   innerWrapperClass: string,
   itemStyle: CSSProperties,
   itemClass: string,

--- a/src/wrapper.tsx
+++ b/src/wrapper.tsx
@@ -43,6 +43,7 @@ interface innerStyleProps {
   dragging: boolean;
   mounted: boolean;
   transition: number;
+  inertiaScrolling: boolean;
 }
 
 /** function to get default styles for innerWrapper */
@@ -51,11 +52,13 @@ export const innerStyle = ({
   dragging,
   mounted,
   transition,
+  inertiaScrolling,
 }: innerStyleProps): CSSProperties => {
   return {
     width: '9900px',
     transform: `translate3d(${translate}px, 0px, 0px)`,
-    transition: `transform ${dragging || !mounted ? '0' : transition}s`,
+    transition: `transform ${dragging || !mounted ? '0' : transition}s` +
+                (inertiaScrolling ? ' ease-out' : '') ,
   };
 };
 
@@ -74,6 +77,7 @@ interface InnerWrapperProps {
   itemStyle: object;
   itemClass: string;
   itemClassActive: string;
+  inertiaScrolling: boolean;
 }
 
 //** innerWrapper component, menuItems will be children */
@@ -142,6 +146,7 @@ export class InnerWrapper extends React.PureComponent<InnerWrapperProps, {}> {
       itemClassActive,
       data,
       selected,
+      inertiaScrolling,
     } = this.props;
 
     const items = this.setItems(data, selected);
@@ -151,6 +156,7 @@ export class InnerWrapper extends React.PureComponent<InnerWrapperProps, {}> {
       dragging,
       mounted,
       transition,
+      inertiaScrolling,
     });
 
     const wrapperStyles = { ...style, ...innerWrapperStyle };


### PR DESCRIPTION
Adding support for inertia scrolling, therefore improving UX on mobile.

The drag handler records timestamp and position, when drag ends, the average speed of last 150ms is calculated and using this speed the final translate-position is calculated. A normal css-transition is used to create an effect of inertia.

Activate inertia scrolling with `inertiaScrolling` You can control the duration of inertia with existing `transition` option, furthermore you have the new `inertiaScrollingSlowdown` option, which determines how fast the inertia effect is.