### PR TITLE
use tabindex 0 for a11y

### DIFF
--- a/src/wrapper.tsx
+++ b/src/wrapper.tsx
@@ -231,7 +231,7 @@ export class InnerWrapper extends React.PureComponent<
             key={'menuItem-' + Item.key}
             style={itemStyle}
             onClick={Item.props.onClick()}
-            tabIndex={1}
+            tabIndex={0}
             role={useButtonRole ? 'button' : ''}
           >
             {Item}


### PR DESCRIPTION
I would like to suggest a PR to change `tabindex` to 0 instead of 1.

There is a lot of information on the internet about why `tabindex`'s greater than 0 are less accessible for people using screen readers.

From https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex:
> Avoid using `tabindex` values greater than 0. Doing so will make it difficult for people who rely on assistive technology to navigate and operate page content.

More information here: https://webaim.org/techniques/keyboard/tabindex

It's also worth mentioning that Google Lighthouse audit will reduce the accessibility score because of this tabindex.

<img width="1792" alt="Screen Shot 2019-08-06 at 5 16 16 PM" src="https://user-images.githubusercontent.com/159949/62577977-06b5c580-b86e-11e9-996a-189034cdf161.png">