### PR TITLE
Fixes #82

### DIFF
--- a/src/scrollMenu.tsx
+++ b/src/scrollMenu.tsx
@@ -961,7 +961,7 @@ export class ScrollMenu extends React.Component<MenuProps, MenuState> {
 
   /** wrapper for handleDrag event to avoid memory leak */
   public handleDragWrapper = (
-    e: Event,
+    e: React.MouseEvent | React.TouchEvent | Event,
   ): Void => {
     this.handleDrag(e);
   }

--- a/src/scrollMenu.tsx
+++ b/src/scrollMenu.tsx
@@ -963,7 +963,7 @@ export class ScrollMenu extends React.Component<MenuProps, MenuState> {
   public handleDragWrapper = (
     e: Event,
   ): Void => {
-    this.handleDrag();
+    this.handleDrag(e);
   }
 
   /** drag event handler */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,33 +22,9 @@ const validateTranslate = (value: any, defaultValue: number): number =>
     ? +value
     : defaultValue;
 
-/** test passive event support, for performance */
-// maybe use separate package detect-passive-events
-const testPassiveEventSupport = (): boolean => {
-  let passiveSupported = false;
-
-  try {
-    const options = {
-      get passive() {
-        // This function will be called when the browser
-        // attempts to access the passive property.
-        passiveSupported = true;
-        return false;
-      },
-    };
-
-    window.addEventListener('testPassiveEventSupport', options as any, options);
-    window.removeEventListener('testPassiveEventSupport', options as any, options as any);
-  } catch (err) {
-    passiveSupported = false;
-  }
-  return passiveSupported;
-};
-
 export {
   notUndefOrNull,
   getClientRect,
-  testPassiveEventSupport,
   validateTranslate,
   translateIsValid,
   formatTranslate,


### PR DESCRIPTION
Passing same function to document.addEventListener and react caused memory lead. I've just added wrapper function for document.addEventLister which eventually call proper functions. Also with that passiveEvents feature memory was leaked too, probably when you set third parameter in addEventListener - exact same object must be passed to removeEventListener as third parameter.. I am not sure so I just removed it, revert it back if you need it.