### PR TITLE
[fix] Removing large width causing Chrome flickering

### DIFF
--- a/src/wrapper.spec.js
+++ b/src/wrapper.spec.js
@@ -12,7 +12,7 @@ describe('wrappers and styles', () => {
   it('set correct innerStyle', () => {
     let style, result;
     result = {
-      width: '990000px',
+      whiteSpace: 'nowrap',
       transform: 'translate3d(10px, 0, 0)',
       transition: 'transform 0s',
     };

--- a/src/wrapper.tsx
+++ b/src/wrapper.tsx
@@ -62,7 +62,7 @@ export const innerStyle = ({
     transition:
       `transform ${dragging || !mounted ? '0' : transition}s` +
       (inertiaScrolling ? ' ease-out' : ''),
-    width: '990000px',
+    whiteSpace: 'nowrap',
   };
 };
 


### PR DESCRIPTION
Repacing large hard-coded width causing Chrome flickering by a `white-space: nowrap `