### PR TITLE
fix: nextjs complaining about useLayoutEffect

### DIFF
--- a/example-nextjs/pages/index.tsx
+++ b/example-nextjs/pages/index.tsx
@@ -296,7 +296,6 @@ function Card({
   );
 }
 
-// TODO: nextjs complains about useLayoutEffect
 const Wrapper = () => {
   const [mounted, setMounted] = React.useState(false);
 

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -4,6 +4,7 @@ import { getNodesFromRefs, observerEntriesToItems } from '../helpers';
 import type { Item, Refs, visibleItems } from '../types';
 import { observerOptions } from '../settings';
 import ItemsMap from '../ItemsMap';
+import useIsomorphicLayoutEffect from './useIsomorphicLayoutEffect';
 
 interface Props {
   items: ItemsMap;
@@ -48,7 +49,7 @@ function useIntersection({ items, itemsChanged, refs, options }: Props) {
     [items, options]
   );
 
-  React.useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     const elements = getNodesFromRefs(refs);
     const observerInstance =
       observer.current || new IntersectionObserver(ioCb, options);

--- a/src/hooks/useIsomorphicLayoutEffect.ts
+++ b/src/hooks/useIsomorphicLayoutEffect.ts
@@ -1,0 +1,6 @@
+import React from 'react';
+
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect;
+
+export default useIsomorphicLayoutEffect;


### PR DESCRIPTION
# Fix useLayoutEffect warning in Next.js (SSR)

## Proposed Changes
  - Using an isomorphic hook that interchanges useLayoutEffect with useEffect during SSR (when `window` is undefined). This approach is used in react-redux and other libraries (see [this Medium article](https://medium.com/@alexandereardon/uselayouteffect-and-ssr-192986cdcf7a)).

## Breaking Changes
  - None