### PR TITLE
fix(types.ts): change ItemType's type to ReactNode

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@ export interface Refs {
   [key: string]: React.MutableRefObject<HTMLElement | null>;
 }
 
-export type ItemType = React.ReactElement<{
+export type ItemType = React.ReactNode<{
   /**
     Required. id for every item, should be unique
    */


### PR DESCRIPTION
fix #236


[comment]: # (What it's about. Adding feature or fixing a bug)
# PR title

[comment]: # (Description of changes)
## Proposed Changes
- Changing type of `ItemType` from `ReactElement` to `ReactNode` in order to support multiple children use case

[comment]: # (Fill out if it change or break existing API)
## Breaking Changes
- None
