### PR TITLE
Add `package.json#exports.types` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-horizontal-scrolling-menu",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "author": "asmyshlyaev177",
   "description": "Scrolling horizontal menu component for React, support mouse and touch devices.",
   "license": "ISC",
@@ -19,7 +19,8 @@
       "module": "./dist/index.mjs",
       "import": "./dist/index.mjs",
       "umd": "./dist/index.cjs",
-      "require": "./dist/index.cjs"
+      "require": "./dist/index.cjs",
+      "types": "./dist/types/index.d.ts"
     },
     "./dist/styles.css": "./dist/styles.css",
     "./styles.css": "./dist/styles.css"


### PR DESCRIPTION
[comment]: # (What it's about. Adding feature or fixing a bug)
# Add `package.json#exports.types` field

[comment]: # (Description of changes)
## Proposed Changes
  - Add `"types": "./dist/types/index.d.ts"` to the `package.json`
    - This fixes TS complaining that types don't exist on projects using `typescript@>=4.9.0` and `--moduleResolution node16 (or higher)`
    - See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html#exports-is-prioritized-over-typesversions

[comment]: # (Fill out if it change or break existing API)
## Breaking Changes

N/A
