### PR TITLE
Remove version constraint from install recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Check out examples on [Storybook](https://asmyshlyaev177.github.io/react-horizon
 ## Quick start
 
 ```bash
-npm install --save react-horizontal-scrolling-menu@7.1.1 // last version has a bug
+npm install --save react-horizontal-scrolling-menu
 ```
 test
 In project:


### PR DESCRIPTION
Just a small change, but seeing that there's been a new major since v7, this seems to be redundant .. ? 😉 